### PR TITLE
change IJsonStreamConverter to be non-generic

### DIFF
--- a/src/LaunchDarkly.JsonStream/IJsonStreamConverter.cs
+++ b/src/LaunchDarkly.JsonStream/IJsonStreamConverter.cs
@@ -4,23 +4,30 @@ namespace LaunchDarkly.JsonStream
     /// <summary>
     /// Interface for an object that knows how to convert some type to or from JSON.
     /// </summary>
-    /// <typeparam name="T">the type to be converted</typeparam>
+    /// <remarks>
+    /// This interface uses the type <c>object</c> instead of specifying the actual target
+    /// object type as a generic type parameter. This is because <see cref="JsonStreamConvert"/>
+    /// may need to use reflection to access this interface, and <c>ref struct</c> types like
+    /// <c>JReader</c> aren't compatible with that mechanism. It is the implementator's job to
+    /// ensure that the converter uses the appropriate type; otherwise a type cast error will
+    /// occur.
+    /// </remarks>
     /// <seealso cref="JsonStreamConvert"/>
     /// <seealso cref="JsonStreamConverterAttribute"/>
-    public interface IJsonStreamConverter<T>
+    public interface IJsonStreamConverter
     {
         /// <summary>
         /// Writes the JSON representation of an object.
         /// </summary>
         /// <param name="instance">the object</param>
         /// <param name="writer">the streaming writer</param>
-        void WriteJson(T instance, IValueWriter writer);
+        void WriteJson(object instance, IValueWriter writer);
 
         /// <summary>
         /// Reads an object from its JSON representation.
         /// </summary>
         /// <param name="reader">the streaming reader</param>
         /// <returns>the deserialized object</returns>
-        T ReadJson(ref JReader reader);
+        object ReadJson(ref JReader reader);
     }
 }

--- a/src/LaunchDarkly.JsonStream/JsonStreamConverterSystemTextJson.cs
+++ b/src/LaunchDarkly.JsonStream/JsonStreamConverterSystemTextJson.cs
@@ -18,15 +18,15 @@ namespace LaunchDarkly.JsonStream
             var attr = JsonStreamConverterAttribute.ForTargetType(typeToConvert);
             return (JsonConverter)Activator.CreateInstance(
                 typeof(ConverterImpl<>).MakeGenericType(typeToConvert),
-                attr.UntypedConverter
+                attr.Converter
                 );
         }
 
         private sealed class ConverterImpl<T> : JsonConverter<T>
         {
-            private IJsonStreamConverter<T> _jsonStreamConverter;
+            private IJsonStreamConverter _jsonStreamConverter;
 
-            public ConverterImpl(IJsonStreamConverter<T> jsonStreamConverter)
+            public ConverterImpl(IJsonStreamConverter jsonStreamConverter)
             {
                 _jsonStreamConverter = jsonStreamConverter;
             }
@@ -41,7 +41,7 @@ namespace LaunchDarkly.JsonStream
                 // delegate, but it's still better than actually parsing the JSON twice.
                 var jsonDocument = JsonDocument.ParseValue(ref reader);
                 var readerWrapper = JReader.FromAdapter(ReaderAdapters.FromJsonElement(jsonDocument.RootElement));
-                return _jsonStreamConverter.ReadJson(ref readerWrapper);
+                return (T)_jsonStreamConverter.ReadJson(ref readerWrapper);
             }
 
             public override void Write(Utf8JsonWriter writer, T value, JsonSerializerOptions options)

--- a/src/LaunchDarkly.JsonStream/LaunchDarkly.JsonStream.csproj
+++ b/src/LaunchDarkly.JsonStream/LaunchDarkly.JsonStream.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <Version>1.0.0-alpha.6</Version>
+    <Version>1.0.0-alpha.7</Version>
     <!--
       The reason there's a mechanism here for overriding the target frameworks with
       an environment variable is that we want to be able to run CI tests using older

--- a/test/LaunchDarkly.JsonStream.Tests/JsonStreamConverterSystemTextJsonTest.cs
+++ b/test/LaunchDarkly.JsonStream.Tests/JsonStreamConverterSystemTextJsonTest.cs
@@ -131,9 +131,9 @@ namespace LaunchDarkly.JsonStream
                 NullableDouble2 == o.NullableDouble2;
         }
 
-        internal class MyTestConverter : IJsonStreamConverter<MyTestClass>
+        internal class MyTestConverter : IJsonStreamConverter
         {
-            public MyTestClass ReadJson(ref JReader reader)
+            public object ReadJson(ref JReader reader)
             {
                 var ret = new MyTestClass();
                 for (var obj = reader.Object(); obj.Next(ref reader);)
@@ -204,8 +204,9 @@ namespace LaunchDarkly.JsonStream
                 return ret;
             }
 
-            public void WriteJson(MyTestClass instance, IValueWriter writer)
+            public void WriteJson(object o, IValueWriter writer)
             {
+                var instance = (MyTestClass)o;
                 var obj = writer.Object();
                 obj.Name("stringProp").String(instance.StringProp);
                 obj.Name("boolProp").Bool(instance.BoolProp);


### PR DESCRIPTION
This PR changes the `IJsonStreamConverter` interface so that instead of being a generic with a type parameter T, and using the T type in the ReadJson and WriteJson methods, it simply uses `object`.

This is a less nice API, but it was necessary in order to support using `JsonStreamConvert` when you don't know the type of the object at compile time, but instead have just a `Type` instance (which we'll have to do if, for instance, we provide an adapter from `Newtonsoft.Json` whose custom serializer interface does not use generics).

The problem is this. If we're in a method that was declared with a type parameter `<T>`, that's great— generics in .NET have full access to type information (i.e. there's no type erasure like in Java), and we can get the converter as a `IJsonStreamConverter<T>` and just call it straightforwardly. But, if you have a `Type` instead of `<T>`... you can't reference the converter straightforwardly because .NET doesn't allow a wildcard declaration like `IJsonStreamConverter<?>`. So we would need to use reflection, get a reference to the converter's `ReadJson` or `WriteJson` method (without having to declare its type as anything other than `object`), and invoke the method dynamically. But... `ReadJson` has a `ref struct` parameter, which unfortunately there is no way to represent in a reflective call.

So the solution is to simplify `IJsonStreamConverter`, get rid of all the reflection (except for attribute detection), and just use ordinary type casts back and forth from `object, trusting that the converter for type T actually is written for type T and not some other type.