### PR TITLE
change build targets to allow Xamarin use

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -55,7 +55,7 @@ workflows:
       - benchmark-linux:
           name: .NET Core 2.1 benchmarks (Linux)
           docker-image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
-          build-target-frameworks: netstandard2.0
+          build-target-frameworks: netcoreapp2.1
           test-target-framework: netcoreapp2.1
       - benchmark-linux:
           name: .NET Core 3.1 benchmarks (Linux)

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -8,9 +8,17 @@ workflows:
   test:
     jobs:
       - test-linux:
+          name: .NET Core 2.0 using .NET Standard 2.0 (Linux)
+          # .NET Core 2.0 is obsolete, but this is how we verify that the .NET
+          # Standard 2.0 build (which doesn't use System.Text.Json) works as intended.
+          docker-image: microsoft/dotnet:2.0-sdk-jessie
+          build-target-frameworks: netstandard2.0
+          test-target-framework: netcoreapp2.0
+          uses-native-implementation: false
+      - test-linux:
           name: .NET Core 2.1 (Linux)
           docker-image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal
-          build-target-frameworks: netstandard2.0
+          build-target-frameworks: netcoreapp2.1
           test-target-framework: netcoreapp2.1
           uses-native-implementation: true
       - test-linux:

--- a/README.md
+++ b/README.md
@@ -8,17 +8,24 @@
 
 The `LaunchDarkly.JsonStream` library implements a streaming approach to JSON encoding and decoding designed for efficiency at high volume, assuming a text encoding of UTF8. Unlike reflection-based frameworks, it has no knowledge of structs or other complex types; you must explicitly tell it what values and properties to write or read. It was implemented for the [LaunchDarkly .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk) and [LaunchDarkly Xamarin SDK](http://github.com/launchdarkly/xamarin-client-sdk), but may be useful in other applications.
 
-On platforms where `System.Text.Json` is available either in the standard runtime library (.NET Core 3.1+, .NET 5.0+) or as a NuGet package (all other platforms except .NET Framework 4.5.2), this works as a wrapper for `System.Text.Json.Utf8JsonReader` and `System.Text.Json.Utf8Jsonwriter`, providing a more convenient API for common JSON parsing and writing operations while taking advantage of the very efficient implementation of these core types. On platforms that do not have `System.Text.Json` (.NET Framework 4.5.2), it falls back to a portable implementation that is not as fast as `System.Text.Json` but still highly efficient. Portable JSON unmarshaling logic can therefore be written against this API without needing to know the target platform.
-
-## Supported .NET versions
+## Supported .NET versions and platform differences
 
 This version of the SDK is built for the following targets:
 
-* .NET Core 3.1: runs on .NET Core 3.1+.
-* .NET 5.0: runs on .NET 5.x.
-* .NET Framework 4.5.2: runs on .NET Framework 4.5.2 and above. This uses the portable implementation instead of `System.Text.Json`.
-* .NET Framework 4.6.1: runs on .NET Framework 4.6.1 and above.
-* .NET Standard 2.0: runs on .NET Core 2.x, in an application; or within a library that is targeted to .NET Standard 2.x.
+* .NET Core 3.1+
+* .NET Core 2.1+
+* .NET 5.0+
+* .NET Framework 4.5.2+
+* .NET Framework 4.6.1+
+* .NET Standard 2.0 (used on other platforms such as Xamarin)
+
+## `System.Text.Json` support
+
+All builds of `LaunchDarkly.JsonStream` except for .NET Framework 4.5.2 and .NET Standard 2.0 make use of the `System.Text.Json` API, which is built into the standard runtime library for .NET Core 3.x and .NET 5.x and is imported as a NuGet package on other platforms. `System.Text.Json` is the new standard .NET API for JSON handling, and is optimized for operating on UTF-8-encoded text. Any types that use the `LaunchDarkly.JsonStream.JsonStreamConverter` attribute will automatically be recognized by `System.Text.Json`'s reflection-based APIs.
+
+The .NET Framework and .NET Standard 2.0 builds of `LaunchDarkly.JsonStream` use a different portable implementation that is not as fast as `System.Text.Json`, but still highly efficient. `System.Text.Json` is not available for .NET Framework 4.5.2. It is available for .NET Standard 2.0, but the .NET Standard 2.0 target of `LaunchDarkly.JsonStream` is also used in Xamarin, and `System.Text.Json` currently has compatibility problems with Xamarin.
+
+The external API of the library is the same regardless, so portable JSON encoding/decoding logic can be written against `LaunchDarkly.JsonStream` without needing to know the target platform.
 
 ## Signing
 

--- a/README.md
+++ b/README.md
@@ -21,7 +21,7 @@ This version of the SDK is built for the following targets:
 
 ## `System.Text.Json` support
 
-All builds of `LaunchDarkly.JsonStream` except for .NET Framework 4.5.2 and .NET Standard 2.0 make use of the `System.Text.Json` API, which is built into the standard runtime library for .NET Core 3.x and .NET 5.x and is imported as a NuGet package on other platforms. `System.Text.Json` is the new standard .NET API for JSON handling, and is optimized for operating on UTF-8-encoded text. Any types that use the `LaunchDarkly.JsonStream.JsonStreamConverter` attribute will automatically be recognized by `System.Text.Json`'s reflection-based APIs.
+All builds of `LaunchDarkly.JsonStream` except for .NET Framework 4.5.2 and .NET Standard 2.0 make use of the `System.Text.Json` API, which is built into the standard runtime library for .NET Core 3.x and .NET 5.x and is imported as a NuGet package on other platforms. Any types that use the `LaunchDarkly.JsonStream.JsonStreamConverter` attribute will automatically be recognized by `System.Text.Json`'s reflection-based APIs.
 
 The .NET Framework and .NET Standard 2.0 builds of `LaunchDarkly.JsonStream` use a different portable implementation that is not as fast as `System.Text.Json`, but still highly efficient. `System.Text.Json` is not available for .NET Framework 4.5.2. It is available for .NET Standard 2.0, but the .NET Standard 2.0 target of `LaunchDarkly.JsonStream` is also used in Xamarin, and `System.Text.Json` currently has compatibility problems with Xamarin.
 

--- a/src/LaunchDarkly.JsonStream/LaunchDarkly.JsonStream.csproj
+++ b/src/LaunchDarkly.JsonStream/LaunchDarkly.JsonStream.csproj
@@ -7,7 +7,7 @@
       SDKs which do not consider "net5.0" to be a valid target framework that can be
       referenced in a project file.
     -->
-    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp3.1;net5.0;net452;net461</BuildFrameworks>
+    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0;net452;net461</BuildFrameworks>
     <TargetFrameworks>$(BUILDFRAMEWORKS)</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>LaunchDarkly.JsonStream</AssemblyName>
@@ -25,14 +25,18 @@
     <DocumentationFile>bin\$(Configuration)\$(TargetFramework)\LaunchDarkly.JsonStream.xml</DocumentationFile>
   </PropertyGroup>
 
-  <!-- System.Text.Json is built into the standard library in .NET Core 3.x and .NET 5.0.
-       It is available as a NuGet package in .NET Standard 2.0 and .NET Framework 4.6.1.
-       It is not available in .NET Framework 4.5.2. -->
-  <ItemGroup Condition="'$(TargetFramework)' == 'netstandard2.0' or '$(TargetFramework)' == 'net461'">
+  <!--
+      For an explanation of why we do or don't use System.Text.Json on various
+      platforms, see README.md
+  -->
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.1'
+                     or '$(TargetFramework)' == 'net461'">
     <PackageReference Include="System.Text.Json" Version="5.0.0" />
+    <!-- it's a built-in package in netcoreapp3.1 and net5.0 -->
   </ItemGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net452'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0'
+                        and '$(TargetFramework)' != 'net452'">
     <!-- USE_SYSTEM_TEXT_JSON is what we look for in conditionally-compiled code -->
     <DefineConstants>$(DefineConstants);USE_SYSTEM_TEXT_JSON</DefineConstants>
   </PropertyGroup>

--- a/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
+++ b/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
@@ -6,13 +6,13 @@
       SDKs which do not consider "net5.0" to be a valid target framework that can be
       referenced in a project file.
     -->
-    <TestFrameworks Condition="'$(TESTFRAMEWORKS)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0;net452;net461</TestFrameworks>
+    <TestFrameworks Condition="'$(TESTFRAMEWORKS)' == ''">netcoreapp2.0;netcoreapp2.1;netcoreapp3.1;net5.0;net452;net461</TestFrameworks>
     <TargetFrameworks>$(TESTFRAMEWORKS)</TargetFrameworks>
     <RootNamespace>LaunchDarkly.JsonStream</RootNamespace>
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0'
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'
                         and '$(TargetFramework)' != 'net452'">
     <!-- USE_SYSTEM_TEXT_JSON is what we look for in conditionally-compiled code -->
     <DefineConstants>$(DefineConstants);USE_SYSTEM_TEXT_JSON</DefineConstants>

--- a/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
+++ b/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
@@ -12,7 +12,8 @@
     <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
-  <PropertyGroup Condition="'$(TargetFramework)' != 'net452'">
+  <PropertyGroup Condition="'$(TargetFramework)' != 'netstandard2.0'
+                        and '$(TargetFramework)' != 'net452'">
     <!-- USE_SYSTEM_TEXT_JSON is what we look for in conditionally-compiled code -->
     <DefineConstants>$(DefineConstants);USE_SYSTEM_TEXT_JSON</DefineConstants>
   </PropertyGroup>

--- a/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
+++ b/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
@@ -17,14 +17,20 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="xunit" Version="2.4.1" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3">
-      <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
-      <PrivateAssets>all</PrivateAssets>
-    </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
     <PackageReference Include="Newtonsoft.Json" Version="12.0.3" />
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'netcoreapp2.0'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="15.0.0" />
+    <PackageReference Include="xunit" Version="2.2.0" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.2.0" />
   </ItemGroup>
 
   <ItemGroup>

--- a/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
+++ b/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
@@ -9,6 +9,7 @@
     <TestFrameworks Condition="'$(TESTFRAMEWORKS)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0;net452;net461</TestFrameworks>
     <TargetFrameworks>$(TESTFRAMEWORKS)</TargetFrameworks>
     <RootNamespace>LaunchDarkly.JsonStream</RootNamespace>
+    <LangVersion>7.3</LangVersion>
   </PropertyGroup>
 
   <PropertyGroup Condition="'$(TargetFramework)' != 'net452'">


### PR DESCRIPTION
Background: the original release of this library had quite a few build targets, but none specifically for Xamarin; we assumed Xamarin code would use the .NET Standard 2.0 build, since no Xamarin-specific features are required. We also didn't bother to add a .NET Core 2.1 target because we assumed .NET Core 2.x code would use .NET Standard as well.

Unfortunately, it turns out `System.Text.Json` doesn't work in Xamarin iOS (it looks like the same problem as [this fairly old known issue](https://github.com/dotnet/runtime/issues/31326)). Theoretically, we could add some Xamarin-specific build targets that would have the `System.Text.Json` integration turned off... but that would be quite a hassle, due to limitations in cross-platform support in .NET tools (there's no single machine that can build for _both_ .NET Framework and Xamarin).

So, this PR turns off the `System.Text.Json` integration in the .NET Standard 2.0 target— and also adds a .NET Core 2.1 target that does use `System.Text.Json`, so any .NET Core 2.x code using this library won't notice any difference. Any other code that's using the .NET Standard 2.0 target is almost certainly for Xamarin, where this wasn't working anyway.

Since we want to exercise all of our builds in the CI tests, and running a Xamarin app isn't practical, I added a job that runs the test code on the very obsolete .NET Core 2.0 platform... which will pick up the .NET Standard 2.0 version of the library. The actual proof of whether this works in Xamarin will be in the Xamarin SDK unit tests, but there's no reason to think it won't, since it uses nothing but bog-standard .NET Standard 2.0 APIs and has no package dependencies.