### PR TITLE
fix bug in parsing number with exponent but no decimal

### DIFF
--- a/src/LaunchDarkly.JsonStream/Implementation/TokenReaderInternalSimple.cs
+++ b/src/LaunchDarkly.JsonStream/Implementation/TokenReaderInternalSimple.cs
@@ -168,18 +168,18 @@ namespace LaunchDarkly.JsonStream.Implementation
 
 		private double ReadNumber(char firstCh)
 		{
-			var hasDecimal = false;
+			var isFloat = false;
 			char ch = (char)0;
 			for (; _pos < _length; _pos++)
 			{
 				ch = _buf[_pos];
-				if (!char.IsDigit(ch) && !(ch == '.' && !hasDecimal))
+				if (!char.IsDigit(ch) && !(ch == '.' && !isFloat))
 				{
 					break;
 				}
 				if (ch == '.')
 				{
-					hasDecimal = true;
+					isFloat = true;
 				}
 			}
 			if (ch == 'e' || ch == 'E')
@@ -188,7 +188,7 @@ namespace LaunchDarkly.JsonStream.Implementation
 				_pos++;
 				if (_pos >= _length)
 				{
-					throw new Exception("no"); // TODO
+					throw MakeSyntaxException("invalid number format");
 				}
 				ch = _buf[_pos];
 				if (ch == '+' || ch == '-')
@@ -197,9 +197,9 @@ namespace LaunchDarkly.JsonStream.Implementation
 				}
 				else if (ch < '0' || ch > '9')
 				{
-					throw new Exception("no"); // TODO
+					throw MakeSyntaxException("invalid number format");
 				}
-				var haveExpDigits = false;
+				var hasExponent = false;
 				for (; _pos < _length; _pos++)
 				{
 					ch = _buf[_pos];
@@ -207,15 +207,16 @@ namespace LaunchDarkly.JsonStream.Implementation
 					{
 						break;
 					}
-					haveExpDigits = true;
+					hasExponent = true;
 				}
-				if (!haveExpDigits)
+				if (!hasExponent)
 				{
-					throw new Exception("no"); // TODO
+					throw MakeSyntaxException("invalid number format");
 				}
+				isFloat = true;
 			}
 			var st = StringToken.FromChars(_buf, _lastPos, _pos - _lastPos);
-			return hasDecimal ? st.ParseDouble() : st.ParseLong();
+			return isFloat ? st.ParseDouble() : st.ParseLong();
 		}
 
 		private StringToken ReadString()

--- a/test/LaunchDarkly.JsonStream.Tests/TestSuite/TestValues.cs
+++ b/test/LaunchDarkly.JsonStream.Tests/TestSuite/TestValues.cs
@@ -85,10 +85,14 @@ namespace LaunchDarkly.JsonStream.TestSuite
                 new NumberTestValue("int large", 1603312301195, "1603312301195", null), // enough magnitude for a millisecond timestamp
 		        new NumberTestValue("float", 3.5, "3.5", null),
                 new NumberTestValue("float negative", -3.5, "-3.5", null),
-                new NumberTestValue("float with exp", 3500, "3.5e3", "3500"),
-                new NumberTestValue("float with Exp", 3500, "3.5E3", "3500"),
-                new NumberTestValue("float with exp+", 3500, "3.5e+3", "3500"),
-                new NumberTestValue("float with exp-", 0.0035, "3.5e-3", "0.0035")
+                new NumberTestValue("float with exp and decimal", 3500, "3.5e3", "3500"),
+                new NumberTestValue("float with Exp and decimal", 3500, "3.5E3", "3500"),
+                new NumberTestValue("float with exp+ and decimal", 3500, "3.5e+3", "3500"),
+                new NumberTestValue("float with exp- and decimal", 0.0035, "3.5e-3", "0.0035"),
+                new NumberTestValue("float with exp but no decimal", 5000, "5e3", "5000"),
+                new NumberTestValue("float with Exp but no decimal", 5000, "5E3", "5000"),
+                new NumberTestValue("float with exp+ but no decimal", 5000, "5e+3", "5000"),
+                new NumberTestValue("float with exp- but no decimal", 0.005, "5e-3", "0.005")
             };
             var ret = new List<ValueTest<T>>();
             foreach (var ntv in ntvs)


### PR DESCRIPTION
In JSON, `100000`, `1.0e+5`, `1.0e5`, `1e+5`, and `1e5` are all equally valid ways of encoding the same number. Unfortunately, our basic implementation of JSON parsing (that we use in this library when System.Text.Json isn't available) only recognized the first three of those formats, and rejected the last two with a spurious syntax error. The bug was missed because our parser test suite did not include an example of the last two formats.