### PR TITLE
add .NET 6.0 target framework

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -26,12 +26,23 @@ workflows:
       - test-linux:
           name: .NET 5.0 (Linux)
           docker-image: mcr.microsoft.com/dotnet/sdk:5.0-focal
+          build-target-frameworks: net5.0
           test-target-framework: net5.0
           uses-native-implementation: true
       - test-windows:
           name: .NET 5.0 (Windows)
           test-target-framework: net5.0
           uses-native-implementation: true
+      - test-linux:
+          name: .NET 6.0 (Linux)
+          docker-image: mcr.microsoft.com/dotnet/sdk:6.0-focal
+          build-target-frameworks: net6.0
+          test-target-framework: net6.0
+          uses-native-implementation: true
+      - test-windows:
+          name: .NET 6.0 (Windows)
+          test-target-framework: net6.0
+          uses-native-implementation: true        
       - test-windows:
           name: .NET Framework 4.5.2 (Windows)
           test-target-framework: net452

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -50,11 +50,7 @@ workflows:
           name: .NET Framework 4.6.1 (Windows)
           build-target-frameworks: net461
           test-target-framework: net461
-          uses-native-implementation: true
-      - test-windows:
-          name: .NET 5.0 (Windows)
-          test-target-framework: net5.0
-          uses-native-implementation: true        
+          uses-native-implementation: true    
       - benchmark-linux:
           name: .NET Core 2.1 benchmarks (Linux)
           docker-image: mcr.microsoft.com/dotnet/core/sdk:2.1-focal

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -171,12 +171,17 @@ jobs:
 
   benchmark-windows:
     parameters:
+      build-target-frameworks:
+        type: string
+        default: ""
       test-target-framework:
         type: string
     executor:
       name: win/default
       shell: powershell.exe
     environment:
+      BUILDFRAMEWORKS: <<parameters.build-target-frameworks>>
+      TESTFRAMEWORKS: <<parameters.test-target-framework>>
       BUILDBENCHMARKS: true
     steps:
       - checkout

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -21,6 +21,7 @@ workflows:
           uses-native-implementation: true
       - test-windows:
           name: .NET Core 3.1 (Windows)
+          build-target-frameworks: netcoreapp3.1
           test-target-framework: netcoreapp3.1
           uses-native-implementation: true
       - test-linux:
@@ -31,6 +32,7 @@ workflows:
           uses-native-implementation: true
       - test-windows:
           name: .NET 5.0 (Windows)
+          build-target-frameworks: net5.0
           test-target-framework: net5.0
           uses-native-implementation: true
       - test-linux:
@@ -40,15 +42,13 @@ workflows:
           test-target-framework: net6.0
           uses-native-implementation: true
       - test-windows:
-          name: .NET 6.0 (Windows)
-          test-target-framework: net6.0
-          uses-native-implementation: true        
-      - test-windows:
           name: .NET Framework 4.5.2 (Windows)
+          build-target-frameworks: net452
           test-target-framework: net452
           uses-native-implementation: false
       - test-windows:
           name: .NET Framework 4.6.1 (Windows)
+          build-target-frameworks: net461
           test-target-framework: net461
           uses-native-implementation: true
       - test-windows:
@@ -67,16 +67,20 @@ workflows:
           test-target-framework: netcoreapp3.1
       - benchmark-windows:
           name: .NET Core 3.1 benchmarks (Windows)
+          build-target-frameworks: netcoreapp3.1
           test-target-framework: netcoreapp3.1
       - benchmark-linux:
           name: .NET 5.0 benchmarks (Linux)
           docker-image: mcr.microsoft.com/dotnet/sdk:5.0-focal
+          build-target-frameworks: net5.0
           test-target-framework: net5.0
       - benchmark-windows:
           name: .NET 5.0 benchmarks (Windows)
+          build-target-frameworks: net5.0
           test-target-framework: net5.0
       - benchmark-windows:
           name: .NET Framework 4.6.1 benchmarks (Windows)
+          build-target-frameworks: net461
           test-target-framework: net461
           # The .NET Framework version here is 4.6.1 even though LaunchDarkly.JsonStream
           # is compatible with 4.5.2+, because the BenchmarkDotNet library isn't compatible

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -116,6 +116,9 @@ jobs:
 
   test-windows:
     parameters:
+      build-target-frameworks:
+        type: string
+        default: ""
       test-target-framework:
         type: string
       uses-native-implementation:
@@ -124,6 +127,8 @@ jobs:
       name: win/default
       shell: powershell.exe
     environment:
+      BUILDFRAMEWORKS: <<parameters.build-target-frameworks>>
+      TESTFRAMEWORKS: <<parameters.test-target-framework>>
       SHOULD_USE_SYSTEM_TEXT_JSON: <<parameters.uses-native-implementation>>
     steps:
       - checkout

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -5,12 +5,10 @@ publications:
     description: NuGet
 
 jobs:
-  - docker: {}
+  - docker:
+      image: 
     template:
       name: dotnet-linux
-    env:
-      LD_RELEASE_TEST_TARGET_FRAMEWORK: net5.0
-      LD_RELEASE_DOCS_TARGET_FRAMEWORK: netstandard2.0
 
 documentation:
   gitHubPages: true

--- a/.ldrelease/config.yml
+++ b/.ldrelease/config.yml
@@ -8,7 +8,7 @@ jobs:
   - docker:
       image: 
     template:
-      name: dotnet-linux
+      name: dotnet6-linux
 
 documentation:
   gitHubPages: true

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ We encourage pull requests and other contributions from the community. Before su
  
 ### Prerequisites
 
-This project has multiple target frameworks as described in [`README.md`](./README.md). The .NET Framework target can be built only in a Windows environment; the others can be built either with or without a Windows environment. Download and install the latest .NET SDK tools first.
+This project has multiple target frameworks as described in [`README.md`](./README.md). Not all .NET SDK versions are capable of building all target frameworks, so it is preferable to use the latest .NET SDK.
 
 The project has no external package dependencies.
  
@@ -32,10 +32,10 @@ To build all targets of the project without running any tests:
 dotnet build src/LaunchDarkly.JsonStream
 ```
 
-Or, to build only one target (in this case .NET 5.0):
+Or, to build only one target (in this case .NET 6.0):
 
 ```
-dotnet build src/LaunchDarkly.JsonStream -f net5.0
+dotnet build src/LaunchDarkly.JsonStream -f net6.0
 ```
  
 ### Testing
@@ -46,10 +46,10 @@ To run all unit tests, for all targets (this includes .NET Framework, so you can
 dotnet test test/LaunchDarkly.JsonStream.Tests
 ```
 
-Or, to run tests only for one target (in this case .NET 5.0):
+Or, to run tests only for one target (in this case .NET 6.0):
 
 ```
-dotnet test test/LaunchDarkly.JsonStream.Tests -f net5.0
+dotnet test test/LaunchDarkly.JsonStream.Tests -f net6.0
 ```
 
 Note that the unit tests can only be run in Debug configuration. There is an `InternalsVisibleTo` directive that allows the test code to access internal members of the library, and assembly strong-naming in the Release configuration interferes with this.

--- a/README.md
+++ b/README.md
@@ -6,17 +6,18 @@
 
 ## Overview
 
-The `LaunchDarkly.JsonStream` library implements a streaming approach to JSON encoding and decoding designed for efficiency at high volume, assuming a text encoding of UTF8. Unlike reflection-based frameworks, it has no knowledge of structs or other complex types; you must explicitly tell it what values and properties to write or read. It was implemented for the [LaunchDarkly .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk) and [LaunchDarkly Xamarin SDK](http://github.com/launchdarkly/xamarin-client-sdk), but may be useful in other applications.
+The `LaunchDarkly.JsonStream` library implements a streaming approach to JSON encoding and decoding designed for efficiency at high volume, assuming a text encoding of UTF8. Unlike reflection-based frameworks, it has no knowledge of structs or other complex types; you must explicitly tell it what values and properties to write or read. It was implemented for the [LaunchDarkly server-side .NET SDK](https://github.com/launchdarkly/dotnet-server-sdk) and [LaunchDarkly client-side .NET SDK](http://github.com/launchdarkly/dotnet-client-sdk), but may be useful in other applications.
 
 ## Supported .NET versions and platform differences
 
 This version of the SDK is built for the following targets:
 
-* .NET Core 3.1+
-* .NET Core 2.1+
-* .NET 5.0+
-* .NET Framework 4.5.2+
-* .NET Framework 4.6.1+
+* .NET 6.0
+* .NET 5.0
+* .NET Core 3.1
+* .NET Core 2.1
+* .NET Framework 4.5.2
+* .NET Framework 4.6.1 (also works on .NET Framework 4.7)
 * .NET Standard 2.0 (used on other platforms such as Xamarin)
 
 ## `System.Text.Json` support

--- a/benchmark/LaunchDarkly.JsonStream.Benchmarks/LaunchDarkly.JsonStream.Benchmarks.csproj
+++ b/benchmark/LaunchDarkly.JsonStream.Benchmarks/LaunchDarkly.JsonStream.Benchmarks.csproj
@@ -5,7 +5,7 @@
     <!--
       The reason there's a mechanism here for overriding the target frameworks with
       an environment variable is that we want to be able to run CI tests using older
-      SDKs which do not consider "net5.0" to be a valid target framework that can be
+      SDKs which do not consider "net6.0" to be a valid target framework that can be
       referenced in a project file.
 
       Also, the .NET Framework version here is 4.6.1 even though LaunchDarkly.JsonStream

--- a/benchmark/LaunchDarkly.JsonStream.Benchmarks/LaunchDarkly.JsonStream.Benchmarks.csproj
+++ b/benchmark/LaunchDarkly.JsonStream.Benchmarks/LaunchDarkly.JsonStream.Benchmarks.csproj
@@ -12,7 +12,7 @@
       is compatible with 4.5.2+, because the BenchmarkDotNet library isn't compatible
       with .NET Framework 4.5.x.
     -->
-    <TestFrameworks Condition="'$(TESTFRAMEWORKS)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0;net461</TestFrameworks>
+    <TestFrameworks Condition="'$(TESTFRAMEWORKS)' == ''">netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net461</TestFrameworks>
     <TargetFrameworks>$(TESTFRAMEWORKS)</TargetFrameworks>
     <StartupObject>LaunchDarkly.JsonStream.Benchmarks.RunBenchmarks</StartupObject>
   </PropertyGroup>

--- a/src/LaunchDarkly.JsonStream/LaunchDarkly.JsonStream.csproj
+++ b/src/LaunchDarkly.JsonStream/LaunchDarkly.JsonStream.csproj
@@ -7,7 +7,7 @@
       SDKs which do not consider "net5.0" to be a valid target framework that can be
       referenced in a project file.
     -->
-    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0;net452;net461</BuildFrameworks>
+    <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net452;net461</BuildFrameworks>
     <TargetFrameworks>$(BUILDFRAMEWORKS)</TargetFrameworks>
     <LangVersion>7.3</LangVersion>
     <AssemblyName>LaunchDarkly.JsonStream</AssemblyName>

--- a/src/LaunchDarkly.JsonStream/LaunchDarkly.JsonStream.csproj
+++ b/src/LaunchDarkly.JsonStream/LaunchDarkly.JsonStream.csproj
@@ -4,7 +4,7 @@
     <!--
       The reason there's a mechanism here for overriding the target frameworks with
       an environment variable is that we want to be able to run CI tests using older
-      SDKs which do not consider "net5.0" to be a valid target framework that can be
+      SDKs which do not consider "net6.0" to be a valid target framework that can be
       referenced in a project file.
     -->
     <BuildFrameworks Condition="'$(BUILDFRAMEWORKS)' == ''">netstandard2.0;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net452;net461</BuildFrameworks>

--- a/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
+++ b/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
@@ -3,7 +3,7 @@
     <!--
       The reason there's a mechanism here for overriding the target frameworks with
       an environment variable is that we want to be able to run CI tests using older
-      SDKs which do not consider "net5.0" to be a valid target framework that can be
+      SDKs which do not consider "net6.0" to be a valid target framework that can be
       referenced in a project file.
     -->
     <TestFrameworks Condition="'$(TESTFRAMEWORKS)' == ''">netcoreapp2.0;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net452;net461</TestFrameworks>

--- a/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
+++ b/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
@@ -6,7 +6,7 @@
       SDKs which do not consider "net5.0" to be a valid target framework that can be
       referenced in a project file.
     -->
-    <TestFrameworks Condition="'$(TESTFRAMEWORKS)' == ''">netcoreapp2.0;netcoreapp2.1;netcoreapp3.1;net5.0;net452;net461</TestFrameworks>
+    <TestFrameworks Condition="'$(TESTFRAMEWORKS)' == ''">netcoreapp2.0;netcoreapp2.1;netcoreapp3.1;net5.0;net6.0;net452;net461</TestFrameworks>
     <TargetFrameworks>$(TESTFRAMEWORKS)</TargetFrameworks>
     <RootNamespace>LaunchDarkly.JsonStream</RootNamespace>
     <LangVersion>7.3</LangVersion>
@@ -24,8 +24,9 @@
   </ItemGroup>
 
   <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.console" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 

--- a/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
+++ b/test/LaunchDarkly.JsonStream.Tests/LaunchDarkly.JsonStream.Tests.csproj
@@ -23,10 +23,19 @@
     <PackageReference Include="YamlDotNet.Signed" Version="5.2.1" />
   </ItemGroup>
 
-  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'">
+  <ItemGroup Condition="'$(TargetFramework)' != 'netcoreapp2.0'
+                    and '$(TargetFramework)' != 'net452'
+                    and '$(TargetFramework)' != 'net461'">
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.0.0" />
     <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.console" Version="2.4.1" />
+    <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
+  </ItemGroup>
+
+  <ItemGroup Condition="'$(TargetFramework)' == 'net452'
+                     or '$(TargetFramework)' == 'net461'">
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="16.7.1" />
+    <PackageReference Include="xunit" Version="2.4.1" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.3" />
   </ItemGroup>
 


### PR DESCRIPTION
Practically speaking I don't think this makes a real difference; our build for .NET 5.0 still works in a .NET 6.0 project. However, since 6.0 is LTS and 5.0 is not, if we don't add this we'll soon be in the slightly awkward position of having our highest specifically-supported version be an EOL one.

I found that the unit test package versions we were using did not work in 6.0, so I had to update those; the newer ones work in all frameworks.