### PR TITLE
fix: Ensure double values are always parsed from JSON using an invariant culture.

### DIFF
--- a/src/LaunchDarkly.JsonStream/Implementation/StringToken.cs
+++ b/src/LaunchDarkly.JsonStream/Implementation/StringToken.cs
@@ -1,4 +1,5 @@
 ﻿using System;
+using System.Globalization;
 
 namespace LaunchDarkly.JsonStream.Implementation
 {
@@ -214,12 +215,12 @@ namespace LaunchDarkly.JsonStream.Implementation
         {
             if (_str != null)
             {
-                return double.Parse(_str);
+                return double.Parse(_str, CultureInfo.InvariantCulture);
             }
 #if NET5_0 || NETCOREAPP3_1
-            return double.Parse(AsSpan());
+            return double.Parse(AsSpan(), NumberStyles.Any, CultureInfo.InvariantCulture.NumberFormat);
 #else
-            return double.Parse(ToString());
+            return double.Parse(ToString(), CultureInfo.InvariantCulture);
 #endif
         }
     }

--- a/test/LaunchDarkly.JsonStream.Tests/StringTokenTest.cs
+++ b/test/LaunchDarkly.JsonStream.Tests/StringTokenTest.cs
@@ -1,4 +1,5 @@
-﻿using Xunit;
+﻿using System.Globalization;
+using Xunit;
 using LaunchDarkly.JsonStream.Implementation;
 
 namespace LaunchDarkly.JsonStream
@@ -73,6 +74,17 @@ namespace LaunchDarkly.JsonStream
             Assert.Equal(n, StringToken.FromString(s).ParseDouble());
             Assert.Equal(n, StringToken.FromChars(("x" + s + "z").ToCharArray(),
                 1, s.Length).ParseDouble());
+        }
+
+        [Theory]
+        [InlineData("fr-FR")]
+        [InlineData("de")]
+        [InlineData("en-US")]
+        public void ParseDoubleCultureInvariant(string cultureName)
+        {
+            System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
+            System.Threading.Thread.CurrentThread.CurrentCulture = new CultureInfo(cultureName);
+            Assert.Equal(0.5, StringToken.FromString("0.5").ParseDouble());
         }
 
         void ShouldEqual(string expected, StringToken actual)


### PR DESCRIPTION
The JSON stream implementation was not using an invariant culture when parsing doubles. This results in incorrect data or errors for non en-US regions.

"0.5" would become "5" in the "de" locale.
"0.5" would cause a crash in the "fr-FR" locale.

This is because different locales use different symbols for the digit group separator and the decimal separator.

This issue does not affect the latest SDK releases for dotnet server and client because they now use System.Text.Json instead of this implementation.